### PR TITLE
disregard platform-specific/project-agnostic files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,3 @@
-
-.DS_Store*
 *.log
-*.gz
-
 node_modules
 coverage


### PR DESCRIPTION
.DS_STORE and other platform-specific / unrelated to this project files should be globally git ignored rather than at the project level

just using the git ignored files from main koa... not sure why *.gz was there
